### PR TITLE
Removed: Application buffer limits

### DIFF
--- a/trxer.go
+++ b/trxer.go
@@ -21,10 +21,7 @@ import "io"
 
 var UPDATE_INTERVAL = 5
 var PORT = 6666
-
 var DEF_BUFFER_SIZE = 8096 * 8
-var MIN_BUFFER_SIZE = 4096
-var MAX_BUFFER_SIZE = 212992
 
 
 type measurement struct {
@@ -374,20 +371,14 @@ func main() {
 	protoPtr := flag.String("protocol", "udp", "quic, udp or tcp")
 	modePtr := flag.String("mode", "server", "server (\"localhost\") or IP address ")
 	threadPtr := flag.Int("threads", 1, "an int for numer of coroutines")
-	callSizePtr := flag.Int("call-size", DEF_BUFFER_SIZE, "quic application buffer in bytes")
+	callSizePtr := flag.Int("call-size", DEF_BUFFER_SIZE, "application buffer in bytes")
 
 	flag.Parse()
 	fmt.Println("trxer(c) - 2017")
 	fmt.Println("Protocol:", *protoPtr)
 	fmt.Println("Mode:", *modePtr)
 	fmt.Println("Threads:", *threadPtr)
-	fmt.Println("(Quic) Call Size: ", *callSizePtr)
-
-	if *callSizePtr < MIN_BUFFER_SIZE {
-		panic("Min buffer size violated")
-	} else if *callSizePtr > MAX_BUFFER_SIZE {
-		panic("Max buffer size violated")
-	}
+	fmt.Println("Call Size: ", *callSizePtr)
 
 	if *protoPtr == "udp" {
 		if *modePtr == "server" {


### PR DESCRIPTION
I removed the application buffer limits, that are based on
the kernel variables (tcp_wmem, rmem_max). 

I also checked the performance again viaLoopback and direct connection. 
I noticed the following: 
- The best performance is 230 Mbyte/s (tested loopback on the i7 8 x 3,4 GHZ CPU)
- Contrary the Core 2 Duo E8400 (2 x 3 GHZ) delivers in the best case only 23 MByte/s (Consider it has to play server and client!)
- When I check the performance via direct connection the performance doesnt exceed 40 Mbyte/s  






Signed-off-by: monfron <simon.fronhoefer@gmail.com>